### PR TITLE
rename title and tab

### DIFF
--- a/components/Layout/Navigator.tsx
+++ b/components/Layout/Navigator.tsx
@@ -13,7 +13,7 @@ const Navigator: VFC = () => {
     <Stack spacing={1} direction="row">
       <Link href="/">
         <Button variant="text" className={styles.navibutton}>
-          Top
+          トップ
         </Button>
       </Link>
       <Link href="/welcome">
@@ -23,17 +23,17 @@ const Navigator: VFC = () => {
       </Link>
       <Link href="/event">
         <Button variant="text" className={styles.navibutton}>
-          Event
+          解説
         </Button>
       </Link>
       <Link href="/contact">
         <Button variant="text" className={styles.navibutton}>
-          Contact
+          お問い合わせ
         </Button>
       </Link>
       <Link href="/links">
         <Button variant="text" className={styles.navibutton}>
-          Links
+          リンク
         </Button>
       </Link>
       <Link href="/menbers">

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -8,9 +8,12 @@ import styles from '../components/section.module.css'
 
 const Contact: VFC = () => {
   return (
-    <Layout title="Contact - RiPPro(立命館大学情報理工学部プロジェクト団体)" description="RiPProへのコンタクトページ">
+    <Layout
+      title="お問い合わせ - RiPPro(立命館大学情報理工学部プロジェクト団体)"
+      description="RiPProへのコンタクトページ"
+    >
       <div className={styles.section}>
-        <h2>Contact</h2>
+        <h2>お問い合わせ</h2>
         <h3>連絡先</h3>
         入部希望者または質問等がある方は，名前・学部学科・回生を明記の上，下記のメールアドレスにメールをしていただくか，
         下記のRiPProのTwitter公式アカウントにDMしてください．

--- a/pages/event/index.tsx
+++ b/pages/event/index.tsx
@@ -11,7 +11,7 @@ import eventStyles from '../../styles/event.module.css'
 const Event: VFC = () => {
   return (
     <Layout
-      title="Event - RiPPro(立命館大学情報理工学部プロジェクト団体)"
+      title="解説 - RiPPro(立命館大学情報理工学部プロジェクト団体)"
       description="過去に開催したイベント一覧ページ"
     >
       {Events.map((event: EventType) => {

--- a/pages/links.tsx
+++ b/pages/links.tsx
@@ -28,7 +28,7 @@ const LinkSection: VFC<SectionType> = (Props: SectionType): JSX.Element => {
 const Links: VFC = () => {
   return (
     <Layout
-      title="Links - RiPPro(立命館大学情報理工学部プロジェクト団体)"
+      title="リンク - RiPPro(立命館大学情報理工学部プロジェクト団体)"
       description="他サイトへのリンクを記載したページ"
     >
       <div className={styles.section}>

--- a/pages/welcome.tsx
+++ b/pages/welcome.tsx
@@ -19,7 +19,7 @@ const Welcome: VFC = () => {
 
   const isCourceOpen: boolean = courseDateStart < currentDate && currentDate < courseDateEnd
   return (
-    <Layout title="Welcome - RiPPro(立命館大学情報理工学部プロジェクト団体)" description="新歓用ページ">
+    <Layout title="新歓情報 - RiPPro(立命館大学情報理工学部プロジェクト団体)" description="新歓用ページ">
       <div className={`${styles.section} ${welcomeStyles.line}`}>
         <h2>プログラミング(C++)講習会</h2>
         <p>プログラミングに関する講習会を私たちの団体で実施します。</p>
@@ -105,7 +105,7 @@ const Welcome: VFC = () => {
         </div>
         <h2>連絡先</h2>
         <div className={welcomeStyles.bottom}>
-          入部希望者または質問等がある方は，<Link href="/contact">Contactページ</Link>にアクセスしてください。
+          入部希望者または質問等がある方は，<Link href="/contact">お問い合わせ</Link>にアクセスしてください。
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
# 背景
「Top / 新歓情報 / Event / Contact / Link / 部員向け」と並んでいました。
日本語と英語が混在している状態なので、日本語に統一しました。
合わせて、ページのタイトル、リンクも修正しました。